### PR TITLE
DUI custom actions: compatibility for Tasker and other activities

### DIFF
--- a/src/com/nitrogen/settings/preferences/ShortcutPickHelper.java
+++ b/src/com/nitrogen/settings/preferences/ShortcutPickHelper.java
@@ -276,9 +276,12 @@ public class ShortcutPickHelper {
 
     private void completeSetCustomShortcut(Intent data) {
         Intent intent = data.getParcelableExtra(Intent.EXTRA_SHORTCUT_INTENT);
-        /* preserve shortcut name, we want to restore it later */
+        if (intent == null) return;
+        // preserve shortcut name, we want to restore it later
         intent.putExtra(Intent.EXTRA_SHORTCUT_NAME, data.getStringExtra(Intent.EXTRA_SHORTCUT_NAME));
-        String appUri = intent.toUri(0);
+        // standardize the uri scheme to be sure we can launch it
+        // TODO: add compatibility for apps that use ACTION_CONFIRM_PIN_SHORTCUT (drag widget on the home screen)
+        String appUri = intent.toUri(Intent.URI_INTENT_SCHEME);
         appUri = appUri.replaceAll("com.android.contacts.action.QUICK_CONTACT", "android.intent.action.VIEW");
         mListener.shortcutPicked(appUri, getFriendlyShortcutName(intent), false);
     }


### PR DESCRIPTION
a typical Tasker shortcut intent starts like this:
task:Test#Intent;action=net.dinglisch.android.tasker.WIDICKYUM;

we can use URI_INTENT_SCHEME to set the standard "intent:" scheme
instead.
This will also fix the custom action summary for these cases (it was
showing the whole, very long intent uri

Fix also a FC when the intent is null.

Change-Id: Iff05f421e2eab63b7482cc904e5e5a5e750bbcb9