### PR TITLE
Improve 'Power menu when locked' text

### DIFF
--- a/res/values/nitrogen_strings.xml
+++ b/res/values/nitrogen_strings.xml
@@ -272,8 +272,8 @@
     <string name="powermenu_torch">Flashlight</string>
 
     <!-- Power menu on secure lockscreen -->
-    <string name="lockscreen_power_menu_disabled_title">Power menu when locked</string>
-    <string name="lockscreen_power_menu_disabled_summary">Disable power menu on secure lockscreen</string>
+    <string name="lockscreen_power_menu_disabled_title"> Disable power menu when locked</string>
+    <string name="lockscreen_power_menu_disabled_summary">Disables power menu on secure lockscreen</string>
 
     <!-- fingerprint authentication vibration -->
     <string name="fprint_sucess_vib_title">Fingerprint authentication vibration</string>


### PR DESCRIPTION
Let's improve the user experience by not letting the user think that 'Power menu when locked', when toggled on, enables it on the lockscreen. Instead, add a 'Disable' keyword to communicate the function clearly. In the same way, update the summary text to 'Disables power menu on secure lockscreen'.